### PR TITLE
Refelect server port setting

### DIFF
--- a/pm2-service.json
+++ b/pm2-service.json
@@ -12,7 +12,7 @@
                 "NODE_ENV": "development"
             },
             "env_production" : {
-                "PORT": 80,
+                "PORT": 3000,
                 "NODE_ENV": "production"
             }
         }


### PR DESCRIPTION
With changing constitution of server, nginx is available, it doesn't have to set port at privilege ports, 80 and 443.