### PR TITLE
吹き出し関連の訂正

### DIFF
--- a/public/css/urlset.css
+++ b/public/css/urlset.css
@@ -12,6 +12,10 @@
   width: 100%;
   height: 100%;
 }
+
+.urlset_panel a:hover + .baloon{
+  display: block;
+}
  
 .text_overflow_url{
   overflow: hidden;

--- a/public/css/urlset.css
+++ b/public/css/urlset.css
@@ -13,7 +13,7 @@
   height: 100%;
 }
 
-.urlset_panel a:hover + .baloon{
+.urlset_panel a:hover,  .baloon{
   display: block;
 }
  

--- a/public/js/url.js
+++ b/public/js/url.js
@@ -5,10 +5,8 @@ class Url extends React.Component {
     return (
       <div className="urlput_panel">
         <p class="text_overflow_url">
-          <mouse_over>
           <h3>{this.props.title}</h3>
           <a href={this.props.href} target="_blank"></a>
-          </mouse_over>
         </p>
         <p class = "baloon">[this.props.content]</p>
       </div>
@@ -60,10 +58,10 @@ jQuery(function($){
   });
 });
 
-$(function () {
-  $('mouse_over').hover(function() {
-    $(this).next('p').show();
-  }, function(){
-    $(this).next('p').hide();
-  });
-});
+
+
+
+
+
+
+


### PR DESCRIPTION
urlset.jsのmouseoverを削除し、urlput.cssのaタグのhoverに吹き出しの表示を付けました。